### PR TITLE
Fix race condition and coverage report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ script:
   - go test -v -race -covermode=atomic -coverprofile=coverage.out
 
 after_success:
-  - goveralls -coverprofile=coverage.out -service=travis-ci -repotoken $COVERALLS_TOKEN
+  - goveralls -coverprofile=coverage.out -service=travis-ci


### PR DESCRIPTION
`replay_test.go` introduced a race condition making the build fail. It was fixed using channels instead of access the variables directly. Using channel also allow us to get rid of `time.Sleep(50 * time.Millisecond)` as receiving from the channel will automatically block.

The coveralls report was also fixed as per https://github.com/vinci-proxy/layer/pull/5.
